### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Modify the configuration to suit your project. You can read more about [phpDocum
         <output>docs</output>
         <cache>.phpdoc/cache</cache>
     </paths>
-    <template name="markdown" location="vendor/ramynasr/phpdoc-markdown/data/templates" />
+    <template name="vendor/ramynasr/phpdoc-markdown/data/templates/markdown" />
 </phpdocumentor>
 ```
 


### PR DESCRIPTION
Changes the instructions about how to point to the markdown template.

I found that using `name` to provide the full path has more consistent results, unlike using `name` and `location`.